### PR TITLE
Fixed heap buffer overflow in init_tm1637()

### DIFF
--- a/components/tm1637/tm1637.c
+++ b/components/tm1637/tm1637.c
@@ -107,7 +107,7 @@ tm1637_led_t * tm1637_init(gpio_num_t pin_clk, gpio_num_t pin_data) {
 		return NULL;
 	}
 
-	for (int i=0;i<sizeof(segment_idx);i++) {
+	for (int i = 0; i < (sizeof(segment_idx) / sizeof(segment_idx[0])); i++) {
 		led->segment_idx[i] = segment_idx[i];
 	}
 	led->segment_start = segment_start;


### PR DESCRIPTION
When initializing `led->segment_idx` in `tm1637_init()`, there was a miscalculation causing the loop to go 4 times too long. The `sizeof(segment_idx)` needed to be divided by the size of first element or else the loop would step out of range and cause a buffer overflow, corrupting the heap.